### PR TITLE
minio console address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,13 @@ services:
     image: minio/minio:latest
     ports:
      - "9000:9000"
+     - "9001:9001"
     environment:
       - "MINIO_ACCESS_KEY=mlflow_access_key"
       - "MINIO_SECRET_KEY=mlflow_secret_key"
     volumes: 
       - minio_data:/data
-    command: server /data
+    command: server /data --console-address ":9001"
 
   mlflow:
     build:


### PR DESCRIPTION
Веб консоль минио теперь не на 9000 порту. Когда идешь в 9000 порт в браузере, происходит редиректет на порт консоли. Если порт консоли не указать явно в команде он будет взят рандомно и, очевидно, в хост маппинга этого рандомного порта не будет и доступа к консоли тоже.

Вот [docker-compose.yaml](https://raw.githubusercontent.com/minio/minio/master/docs/orchestration/docker-compose/docker-compose.yaml) из документации минио, сделал как у них.